### PR TITLE
Fix support for lower VRAM GPUs

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -61,13 +61,15 @@ class Predictor(BasePredictor):
         self.txt2img_pipe = FluxPipeline.from_pretrained(
             MODEL_CACHE,
             torch_dtype=torch.bfloat16
-        ).to("cuda")
+        )
 
         # Save some VRAM by offloading the model to CPU
         vram = int(torch.cuda.get_device_properties(0).total_memory/(1024*1024*1024))
         if vram < 40:
             print("GPU VRAM < 40Gb - Offloading model to CPU")
-            self.txt2img_pipe.enable_model_cpu_offload()
+            self.txt2img_pipe.enable_sequential_cpu_offload()
+        else:
+            self.txt2img_pipe = self.txt2img_pipe.to("cuda")
         
         print("setup took: ", time.time() - start)
 


### PR DESCRIPTION
I tried running this model on an RTX 4090 with 24GB of memory but the model does not fit in this. I encountered two issues with the current script which this PR resolves:

- There is an attempt to check for lower VRAM GPUs, but this check happens _after_ the `.to("cuda")` call loads the weights into VRAM, resulting in an OOM exception there before we can get to the low VRAM check.
- Even with 24GB of VRAM, model offload runs out of memory so we should use sequential offload instead. This will slow down inference but brings memory usage down to ~2GB peak.